### PR TITLE
Added Cloud Run commands.

### DIFF
--- a/cheatsheets/GCP.md
+++ b/cheatsheets/GCP.md
@@ -217,8 +217,14 @@ GCP functions log analysis – May get useful information from logs associated w
 gcloud functions list
 gcloud functions describe <function name>
 gcloud functions logs read <function name> --limit <number of lines>
+```
+
+GCP Cloud Run analysis – May get useful information from descriptions such as environment variables.
+
+```bash
 gcloud run services list
 gcloud run services describe <service-name>
+gcloud run revisions describe --region=<region> <revision-name>
 ```
 
 Gcloud stores creds in ~/.config/gcloud/credentials.db

--- a/cheatsheets/GCP.md
+++ b/cheatsheets/GCP.md
@@ -217,6 +217,8 @@ GCP functions log analysis – May get useful information from logs associated w
 gcloud functions list
 gcloud functions describe <function name>
 gcloud functions logs read <function name> --limit <number of lines>
+gcloud run services list
+gcloud run services describe <service-name>
 ```
 
 Gcloud stores creds in ~/.config/gcloud/credentials.db


### PR DESCRIPTION
[Cloud Run](https://cloud.google.com/run/) is a relatively new feature of GCP. It provides serverless computing for containers.

CLI reference [https://cloud.google.com/sdk/gcloud/reference/run](https://cloud.google.com/sdk/gcloud/reference/run)

In this PR I have added these commands:

1. List all the cloud run services.
2. Describe a cloud run service.
3. Describe a cloud run revision to get juicy information. (env, secrets, service account information e.t.c).

Thank you!