### PR TITLE
Update Azure AD User Attribute Search

### DIFF
--- a/cheatsheets/Azure.md
+++ b/cheatsheets/Azure.md
@@ -258,7 +258,7 @@ Get-MsolServicePrincipal
 One-liner to search all Azure AD user attributes for passwords
 
 ```powershell
-$users = Get-MsolUser; foreach($user in $users){$props = @();$user | Get-Member | foreach-object{$props+=$_.Name}; foreach($prop in $props){if($user.$prop -like "*password*"){Write-Output ("[*]" + $user.UserPrincipalName + "[" + $prop + "]" + " : " + $user.$prop)}}} 
+$users = Get-MsolUser -All; foreach($user in $users){$props = @();$user | Get-Member | foreach-object{$props+=$_.Name}; foreach($prop in $props){if($user.$prop -like "*password*"){Write-Output ("[*]" + $user.UserPrincipalName + "[" + $prop + "]" + " : " + $user.$prop)}}} 
 ```
 
 ### Az CLI Tool


### PR DESCRIPTION
In orgs with *lots* of users `Get-MsolUser` gives the following output:
![image](https://user-images.githubusercontent.com/51839088/131887480-9d7d9069-c0c6-43ca-89b4-96680fbc2a74.png)

Quick little update to the one-liner to add `-All` :) 